### PR TITLE
 Add support for multi-shot cast

### DIFF
--- a/LibClassicCasterino.lua
+++ b/LibClassicCasterino.lua
@@ -524,7 +524,6 @@ classCasts = {
 
     [20904] = 3, -- Aimed Shot
     [14290] = .2, -- Multi-Shot
-
     [1002] = 2, -- Eyes of the Beast
     [2641] = 5, -- Dismiss pet
     [982] = 10, -- Revive Pet

--- a/LibClassicCasterino.lua
+++ b/LibClassicCasterino.lua
@@ -799,8 +799,6 @@ end
 lib.NPCSpellsTimer = C_Timer.NewTimer(6.5, processNPCSpellTable)
 
 NPCSpells = {
-
-    14290,
     10215,
     16587,
     16651,


### PR DESCRIPTION
Issue seems to be that `GetSpellInfo` returns `0ms` for Mult-Shot even though it has a 0.2 second cast. I don't think it's effected by ranged haste, but hard to tell. 

Seems to work 🤷‍♂ 