### PR TITLE
Fix talent decreases

### DIFF
--- a/LibClassicCasterino.lua
+++ b/LibClassicCasterino.lua
@@ -105,7 +105,7 @@ local function CastStart(srcGUID, castType, spellName, spellID, overrideCastTime
     end
     local decreased = talentDecreased[spellID]
     if decreased then
-        castTime = castTime - decreased
+        castTime = castTime - decreased*1000
     end
     if overrideCastTime then
         castTime = overrideCastTime


### PR DESCRIPTION
talentDecreased table has values in seconds, but it is subtracted from cast duration in milliseconds. This makes any talented cast show incorrectly, i.e. chain lightning always shows at 2.499 seconds instead of 1.5, making this library useless against classes utilizing those talents.